### PR TITLE
Added .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ coverage
 /config/master.key
 
 notes.txt
+
+.DS_Store


### PR DESCRIPTION
This prevents Mac users from accidentally adding the .DS_Store file to the source code.