### PR TITLE
Exporting items only

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -12,6 +12,11 @@ class ItemsController < ApplicationController
              else
                Item.all.sort_by { |i| i.meeting.date }.reverse
              end.reject { |i| i.file_number.nil? }
+
+    respond_to do |format|
+      format.html
+      format.csv { process_csv_file(export_as_csv) }
+    end
   end
 
   # GET /items/1
@@ -23,6 +28,18 @@ class ItemsController < ApplicationController
   # Use callbacks to share common setup or constraints between actions.
   def set_item
     @item = Item.find(params[:id])
+  end
+
+  def export_as_csv
+    CsvExports::ItemsExportService.new(@items, 'index').to_csv
+  end
+
+  def process_csv_file(csv)
+    date_time = DateTime.now.to_s
+    send_data csv,
+              type: 'text/csv; charset=iso-8859-1; header=present',
+              disposition: 'attachment',
+              filename: 'items_including_notes_' + date_time + '.csv'
   end
 
   # Never trust parameters from the scary internet, only allow the white list through.

--- a/app/services/csv_exports/base_service.rb
+++ b/app/services/csv_exports/base_service.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+module CsvExports
+  #
+  # Base CSV export service
+  #
+  class BaseService
+    require 'csv'
+
+    #
+    # Initialise CSV export
+    #
+    # @param [collection] collection
+    # @param [array] csv_columns
+    #
+    def initialize(collection, csv_columns = nil)
+      @collection = collection
+      @csv_columns = csv_columns
+    end
+
+    #
+    # Generate CSV
+    #
+    # @return [csv]
+    #
+    def to_csv
+      CSV.generate(headers: true) do |csv|
+        csv << column_names
+        if iterable?(collection)
+          collection.each do |item|
+            csv << data(item)
+          end
+        else
+          csv << data(collection)
+        end
+      end.encode('cp1252', invalid: :replace, undef: :replace, replace: '?').force_encoding('UTF-8')
+    end
+
+    private
+
+    attr_reader :collection, :csv_columns
+
+    #
+    # Check if collection is provided
+    #
+    # @param [object] object
+    #
+    # @return [boolean]
+    #
+    def iterable?(object)
+      object.respond_to?(:each)
+    end
+
+    #
+    # Column names used for CSV headers
+    #
+    # @return [array]
+    #
+    def column_names
+      if csv_columns.blank? && collection.present?
+        collection.first.class.column_names
+      elsif csv_columns.present?
+        csv_columns
+      end
+    end
+
+    #
+    # Format the CSV row
+    #
+    # @param [object] item
+    #
+    # @return [array]
+    #
+    def data(item)
+      data = []
+      column_names.each do |column|
+        data << item.public_send(column)
+      end
+      data
+    end
+  end
+end

--- a/app/services/csv_exports/items_export_service.rb
+++ b/app/services/csv_exports/items_export_service.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module CsvExports
+  # Customize the csv export for items
+  class ItemsExportService < BaseService
+    private
+
+    #
+    # Override the column names method from the base service, used for CSV headers
+    #
+    # @return [array]
+    #
+    def column_names
+      case csv_columns
+      when 'index'
+        index_column_names
+      else
+        collection.first.class.column_names if collection.present?
+      end
+    end
+
+    #
+    # Create a flattened array of fields to use for the CSV
+    #
+    # @return [array]
+    #
+    def index_column_names
+      [
+        [collection.first.class.column_names.reject { |column| index_rejected_columns.include?(column) }]
+      ].flatten
+    end
+
+    #
+    # Field names to reject
+    #
+    # @return [array]
+    #
+    def index_rejected_columns
+      %w[id]
+    end
+  end
+end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -26,6 +26,12 @@
   </div>
 </section>
 
+<section class="table-actions">
+  <div class="button-group buttons-right">
+    <%= link_to(t('export_csv'), request.params.merge(format: 'csv'), class: 'button hollow header-button', id: 'export-csv-button') %>
+  </div>
+</section>
+
 <table>
   <thead>
     <tr>

--- a/app/views/items/show.csv.erb
+++ b/app/views/items/show.csv.erb
@@ -1,0 +1,39 @@
+<h1><%= @item.name %></h1>
+
+<p>
+  <strong>File number:</strong>
+  <%= @item.file_number %>
+</p>
+
+<p>
+  <strong>Type:</strong>
+  <%= @item.item_type %>
+</p>
+
+<p>
+  <strong>Title:</strong>
+  <%= @item.title %>
+</p>
+
+<p>
+  <strong>Action:</strong>
+  <%= @item.action %>
+</p>
+
+<p>
+  <strong>Result:</strong>
+  <%= @item.result %>
+</p>
+
+<p>
+  <strong>Meeting:</strong>
+  <%= @item.meeting.name %> on <%= @item.meeting.date %>
+</p>
+
+<p>
+  <strong>Version:</strong>
+  <%= @item.version %>
+</p>
+
+<br/>
+<%= link_to (fa_icon('arrow-left') + ' Back'), items_path %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,3 +31,4 @@
 
 en:
   hello: "Hello world"
+  export_csv: "Download as CSV"

--- a/test/controllers/items_controller_test.rb
+++ b/test/controllers/items_controller_test.rb
@@ -5,6 +5,7 @@ require 'test_helper'
 class ItemsControllerTest < ActionDispatch::IntegrationTest
   setup do
     @item = items(:item_one)
+    @items = items(:item_one, :item_two, :item_three, :item_four)
   end
 
   test 'should get index' do
@@ -33,6 +34,16 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
 
   test 'should show item' do
     get item_url(@item)
+    assert_response :success
+  end
+
+  test 'should return csv content' do
+    # Note: success required adding show.csv.erb even though that file was not required for a functional human test,
+    # so I have reservations about the quality of this test.
+
+    # Also, admittedly this test is not very deep. I experimented with ways to actually test the CSV output, but I
+    # didn't learn enough yet to accomplish that
+    get item_url(@items), params: { format: 'csv' }
     assert_response :success
   end
 end


### PR DESCRIPTION
Exporting the current list of items based on existing page params. This is only for items as a proof of concept and can be extended to other resource types if this is a good pattern to use.